### PR TITLE
Update to scijava 34.1.0 and use Location API

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,6 @@
 		<groupId>io.scif</groupId>
 		<artifactId>pom-scifio-tutorials</artifactId>
 		<version>1.0.0-SNAPSHOT</version>
-		<relativePath />
 	</parent>
 
 	<groupId>io.scif</groupId>

--- a/core/src/main/java/io/scif/tutorials/core/FakeTutorialImages.java
+++ b/core/src/main/java/io/scif/tutorials/core/FakeTutorialImages.java
@@ -1,0 +1,47 @@
+package io.scif.tutorials.core;
+
+import org.scijava.io.location.Location;
+import org.scijava.io.location.LocationService;
+
+import io.scif.io.location.TestImgLocation;
+import io.scif.io.location.TestImgLocation.Builder;
+
+// A collection of functions creating fake image {@link Location}s for the SCIFIO 
+// tutorials using {@link TestImgLocation.Builder}
+public class FakeTutorialImages {
+	
+	public static Location hugeImage() {
+		TestImgLocation.Builder b = new Builder();
+		b.axes("X","Y");
+		b.lengths(70000, 80000);
+		Location location = b.build();
+		return location;
+	}
+	
+	// Note:
+	// This is equivalent to using the LocationService to resolve the String input image from
+	// T1aIntroToSCIFIO
+	// final String sampleImage = 
+	//     "8bit-unsigned&pixelType=uint8&lengths=50,50,3,5,7&axes=X,Y,Z,Channel,Time.fake";
+	// Location location = scifio.get(LocationService.class).resolve(sampleImage);
+	public static Location sampleImage() {
+		TestImgLocation.Builder b = new Builder();
+		b.pixelType("uint8"); // set the pixel type
+		b.axes("X", "Y", "Z", "Channel", "Time"); // set new axis names
+		b.lengths(50, 50, 3, 5, 7); // set new axis lengths
+		Location location = b.build(); // build the final location
+		return location;
+	}
+	
+	public static Location sampleIndexedImage() {
+		TestImgLocation.Builder b = new Builder();
+		b.pixelType("uint8"); // set the pixel type
+		b.indexed(true);
+		b.planarDims(3);
+		b.axes("X", "Y", "Channel"); // set new axis names
+		b.lengths(50, 50, 3); // set new axis lengths
+		Location location = b.build(); // build the final location
+		return location;
+	}
+	
+}

--- a/core/src/main/java/io/scif/tutorials/core/FakeTutorialImages.java
+++ b/core/src/main/java/io/scif/tutorials/core/FakeTutorialImages.java
@@ -23,7 +23,7 @@ public class FakeTutorialImages {
 	// T1aIntroToSCIFIO
 	// final String sampleImage = 
 	//     "8bit-unsigned&pixelType=uint8&lengths=50,50,3,5,7&axes=X,Y,Z,Channel,Time.fake";
-	// Location location = scifio.get(LocationService.class).resolve(sampleImage);
+	// Location location = scifio.location().resolve(sampleImage);
 	public static Location sampleImage() {
 		TestImgLocation.Builder b = new Builder();
 		b.pixelType("uint8"); // set the pixel type

--- a/core/src/main/java/io/scif/tutorials/core/T1aIntroToSCIFIO.java
+++ b/core/src/main/java/io/scif/tutorials/core/T1aIntroToSCIFIO.java
@@ -57,7 +57,7 @@ public class T1aIntroToSCIFIO {
 		// We use the {@link LocationService} to resolve our input image to a {@link Location}. 
 		// a Location identifies where the data resides, without necessarily specifying 
 		// how to access that data.
-		Location location = scifio.get(LocationService.class).resolve(sampleImage);
+		Location location = scifio.location().resolve(sampleImage);
 		
 		// This method checks the Context used by our SCIFIO instance for all its
 		// known format plugins, and returns an io.scif.Reader capable of opening

--- a/core/src/main/java/io/scif/tutorials/core/T1aIntroToSCIFIO.java
+++ b/core/src/main/java/io/scif/tutorials/core/T1aIntroToSCIFIO.java
@@ -23,6 +23,10 @@ import io.scif.Reader;
 import io.scif.SCIFIO;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
+
+import org.scijava.io.location.Location;
+import org.scijava.io.location.LocationService;
 
 /**
  * An introduction to the SCIFIO API. Demonstrates basic plane reading.
@@ -32,7 +36,7 @@ import java.io.IOException;
 public class T1aIntroToSCIFIO {
 
 	public static void main(final String... agrs) throws FormatException,
-		IOException
+		IOException, URISyntaxException
 	{
 		// The most convenient way to program against the SCIFIO API is by using
 		// an io.scif.SCIFIO instance. This is basically a "SCIFIO lens" on an
@@ -48,12 +52,17 @@ public class T1aIntroToSCIFIO {
 		// exist on disk - they are defined purely by their file name -  so they're
 		// good for testing.
 		final String sampleImage =
-			"8bit-signed&pixelType=int8&lengths=50,50,3,5,7&axes=X,Y,Z,Channel,Time.fake";
-
+			"8bit-unsigned&pixelType=uint8&lengths=50,50,3,5,7&axes=X,Y,Z,Channel,Time.fake";
+		
+		// We use the {@link LocationService} to resolve our input image to a {@link Location}. 
+		// a Location identifies where the data resides, without necessarily specifying 
+		// how to access that data.
+		Location location = scifio.get(LocationService.class).resolve(sampleImage);
+		
 		// This method checks the Context used by our SCIFIO instance for all its
 		// known format plugins, and returns an io.scif.Reader capable of opening
 		// the specified image's planes.
-		final Reader reader = scifio.initializer().initializeReader(sampleImage);
+		final Reader reader = scifio.initializer().initializeReader(location);
 
 		// ------------------------------------------------------------------------
 		// COMPARISON WITH BIO-FORMATS 4.X

--- a/core/src/main/java/io/scif/tutorials/core/T1bReadingTilesBad.java
+++ b/core/src/main/java/io/scif/tutorials/core/T1bReadingTilesBad.java
@@ -23,6 +23,8 @@ import io.scif.SCIFIO;
 
 import java.io.IOException;
 
+import org.scijava.io.location.Location;
+
 /**
  * WARNING: this code intentionally fails. For functional code, see
  * {@link T1cReadingTilesGood}.
@@ -43,11 +45,15 @@ public class T1bReadingTilesBad {
 		final SCIFIO scifio = new SCIFIO();
 
 		// This time we're going to set up an imageID with planes that won't fit
-		// in a byte array.
-		final String hugeImage = "hugePlane&lengths=70000,80000.fake";
+		// in a byte array. 
+		// For the rest of these tutorials, we will use the {@link TestImgLocation.Builder}
+		// to build fake images for us and return their Location. This is in contrast to creating 
+		// a fake image as a String and then resolving its Location with LocationService like
+		// we did in T1aIntroToSCIFIO.
+		Location hugeImageLocation = FakeTutorialImages.hugeImage();
 
 		// We initialize a reader as we did before
-		final Reader reader = scifio.initializer().initializeReader(hugeImage);
+		final Reader reader = scifio.initializer().initializeReader(hugeImageLocation);
 
 		// Now we'll try the naive thing, and just open all the planes in this
 		// dataset.

--- a/core/src/main/java/io/scif/tutorials/core/T1cReadingTilesGood.java
+++ b/core/src/main/java/io/scif/tutorials/core/T1cReadingTilesGood.java
@@ -27,6 +27,8 @@ import io.scif.SCIFIO;
 import java.io.IOException;
 import java.util.Arrays;
 
+import org.scijava.io.location.Location;
+
 import net.imagej.axis.Axes;
 import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
@@ -47,11 +49,11 @@ public class T1cReadingTilesGood {
 		final SCIFIO scifio = new SCIFIO();
 
 		// This time we're going to set up an image with planes that won't fit
-		// in a 2GB byte array.
-		final String hugeImage = "hugePlane&lengths=70000,80000.fake";
-
+		// in a 2GB byte array and get its Location again.
+		Location hugeImageLocation = FakeTutorialImages.hugeImage();
+		
 		// We initialize a reader as we did before
-		final Reader reader = scifio.initializer().initializeReader(hugeImage);
+		final Reader reader = scifio.initializer().initializeReader(hugeImageLocation);
 
 		// In T1b we saw that the naive use of the API to open planes doesn't
 		// work when the individual planes are too large.

--- a/core/src/main/java/io/scif/tutorials/core/T1dSavingImagePlanes.java
+++ b/core/src/main/java/io/scif/tutorials/core/T1dSavingImagePlanes.java
@@ -55,7 +55,7 @@ public class T1dSavingImagePlanes {
 		final String outPath = "SCIFIOTutorial.png";
 		
 		// We can resolve this Location in the same way as T1aIntroToSCIFIO
-		Location outLoction = scifio.get(LocationService.class).resolve(outPath); 
+		Location outLoction = scifio.location().resolve(outPath); 
 
 		// Clear the file if it already exists.
 		File f = new File(outPath);

--- a/core/src/main/java/io/scif/tutorials/core/T1dSavingImagePlanes.java
+++ b/core/src/main/java/io/scif/tutorials/core/T1dSavingImagePlanes.java
@@ -21,10 +21,14 @@ import io.scif.FormatException;
 import io.scif.Reader;
 import io.scif.SCIFIO;
 import io.scif.Writer;
-import io.scif.io.Location;
+import io.scif.io.location.TestImgLocation;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
+
+import org.scijava.io.location.Location;
+import org.scijava.io.location.LocationService;
 
 /**
  * Tutorial demonstrating use of the Writer component.
@@ -34,31 +38,35 @@ import java.io.IOException;
 public class T1dSavingImagePlanes {
 
 	public static void main(final String... args) throws FormatException,
-		IOException
+		IOException, URISyntaxException
 	{
 		// In this tutorial, we're going to make our .fake sample image
-		// "real". If you look at the FakeFormat source code, you'll notice that
+		// "real". If you look at the TestImgFormat source code, you'll notice that
 		// it doesn't have a functional Writer, so we'll have to translate
 		// to a different Format that can write our fake planes to disk.
 
 		final SCIFIO scifio = new SCIFIO();
-		final String sampleImage =
-			"8bit-signed&pixelType=int8&lengths=50,50,3,5,7&axes=X,Y,Z,Channel,Time.fake";
+		
+		// Create a fake image and get its Location.
+		Location sampleImageLocation = FakeTutorialImages.sampleImage();
 
 		// We'll need a path to write to. By making it a ".png" we are locking in
 		// the final format of the file on disk.
 		final String outPath = "SCIFIOTutorial.png";
+		
+		// We can resolve this Location in the same way as T1aIntroToSCIFIO
+		Location outLoction = scifio.get(LocationService.class).resolve(outPath); 
 
 		// Clear the file if it already exists.
-		final Location l = new Location(scifio.getContext(), outPath);
-		if (l.exists()) l.delete();
+		File f = new File(outPath);
+		if (f.exists()) f.delete();
 
 		// We'll need a reader for the input image
-		final Reader reader = scifio.initializer().initializeReader(sampleImage);
+		final Reader reader = scifio.initializer().initializeReader(sampleImageLocation);
 
 		// .. and a writer for the output path
 		final Writer writer =
-			scifio.initializer().initializeWriter(sampleImage, outPath);
+			scifio.initializer().initializeWriter(sampleImageLocation, outLoction);
 
 		// Note that these initialize methods are used for convenience.
 		// Initializing a reader and a writer requires that you set the source

--- a/core/src/main/java/io/scif/tutorials/core/T2aUntypedComponents.java
+++ b/core/src/main/java/io/scif/tutorials/core/T2aUntypedComponents.java
@@ -26,6 +26,8 @@ import io.scif.SCIFIO;
 
 import java.io.IOException;
 
+import org.scijava.io.location.Location;
+
 /**
  * Demonstrates how individual components can be used together instead of the
  * convenience methods in the T1 tutorials. This is for more advanced SCIFIO
@@ -44,8 +46,9 @@ public class T2aUntypedComponents {
 
 		// As always, we create a context and sample image path first.
 		final SCIFIO scifio = new SCIFIO();
-		final String sampleImage =
-			"8bit-signed&pixelType=int8&lengths=50,50,3,5,7&axes=X,Y,Z,Channel,Time.fake";
+		
+		// Create a fake image and get its Location.
+		Location sampleImageLocation = FakeTutorialImages.sampleImage();
 
 		// This time we'll get a handle on the Format itself, which will allow us
 		// to create the additional components. scifio.format() contains several
@@ -53,12 +56,12 @@ public class T2aUntypedComponents {
 		// NB: This implicitly invokes an io.scif.Checker component to determine
 		// format compatibility. These can also be used individually, e.g. if
 		// given a list of Formats to test.
-		final Format format = scifio.format().getFormat(sampleImage);
+		final Format format = scifio.format().getFormat(sampleImageLocation);
 
 		// Typically the first thing we want to do, after confirming we have a
 		// Format that can support an image, is parse the Metadata of that image.
 		final Parser parser = format.createParser();
-		final Metadata meta = parser.parse(sampleImage);
+		final Metadata meta = parser.parse(sampleImageLocation);
 		System.out.println("Metadata = " + meta);
 
 		// Metadata is used by other components, such as Readers, Writers, and

--- a/core/src/main/java/io/scif/tutorials/core/T2bTypedComponents.java
+++ b/core/src/main/java/io/scif/tutorials/core/T2bTypedComponents.java
@@ -20,11 +20,14 @@ package io.scif.tutorials.core;
 import io.scif.ByteArrayPlane;
 import io.scif.FormatException;
 import io.scif.SCIFIO;
-import io.scif.formats.FakeFormat;
-import io.scif.formats.FakeFormat.Parser;
-import io.scif.formats.FakeFormat.Reader;
+
+import io.scif.formats.TestImgFormat;
+import io.scif.formats.TestImgFormat.Parser;
+import io.scif.formats.TestImgFormat.Reader;
 
 import java.io.IOException;
+
+import org.scijava.io.location.Location;
 
 /**
  * In {@link T2aUntypedComponents} we looked at using the general,
@@ -42,21 +45,21 @@ public class T2bTypedComponents {
 		// if we know exactly what kind of image we're working with?
 
 		final SCIFIO scifio = new SCIFIO();
-		final String sampleImage =
-			"8bit-unsigned&pixelType=uint8&indexed=true&planarDims=3&lengths=50,50,3&axes=X,Y,Channel.fake";
+		
+		Location sampleImageLocation = FakeTutorialImages.sampleIndexedImage();
 
 		// This time, since we know we have a .fake image, we'll get a handle to the
 		// Fake format.
-		final FakeFormat fakeFormat =
-			scifio.format().getFormatFromClass(FakeFormat.class);
+		final TestImgFormat fakeFormat =
+			scifio.format().getFormatFromClass(TestImgFormat.class);
 
 		// Two important points here:
 		// 1 - getformatFromClass is overloaded. You can use any component's class
 		// and get back the corresponding Format.
-		// 2 - we didn't invoke the FakeFormat's constructor.
-		// new FakeFormat() would have given us a Format instance with no context.
-		// new FakeFormat(scifio) would have given us a Format with the correct
-		// context, but wouldn't update the context's FakeFormat singleton. So it
+		// 2 - we didn't invoke the TestImgFormat's constructor.
+		// new TestImgFormat() would have given us a Format instance with no context.
+		// new TestImgFormat(scifio) would have given us a Format with the correct
+		// context, but wouldn't update the context's TestImgFormat singleton. So it
 		// would basically be an orphan Format instance.
 		// Formats have no state, so as long as you want a Format that was
 		// discovered as a plugin, you should access it via the desired context. We
@@ -65,16 +68,16 @@ public class T2bTypedComponents {
 		// Formats provide access to all other components, and with a typed Format
 		// you can create typed components:
 
-		final FakeFormat.Reader reader = (Reader) fakeFormat.createReader();
-		final FakeFormat.Parser parser = (Parser) fakeFormat.createParser();
+		final TestImgFormat.Reader reader = (Reader) fakeFormat.createReader();
+		final TestImgFormat.Parser parser = (Parser) fakeFormat.createParser();
 
 		// Now that we have typed components, we can guarantee the return type
 		// for many methods, and access type-specific API:
 
-		final FakeFormat.Metadata meta = parser.parse(sampleImage);
+		final TestImgFormat.Metadata meta = parser.parse(sampleImageLocation);
 
 		// getColorTable isn't a part of the Metadata API, but since
-		// FakeFormat.Metadata implements HasColorTable, we have access to this
+		// TestImgFormat.Metadata implements HasColorTable, we have access to this
 		// method.
 		System.out.println("Color table: " + meta.getColorTable(0, 0));
 

--- a/core/src/main/java/io/scif/tutorials/core/T3aCustomFormats.java
+++ b/core/src/main/java/io/scif/tutorials/core/T3aCustomFormats.java
@@ -33,17 +33,19 @@ import io.scif.ImageMetadata;
 import io.scif.Plane;
 import io.scif.SCIFIO;
 import io.scif.config.SCIFIOConfig;
-import io.scif.io.RandomAccessInputStream;
-import io.scif.io.RandomAccessOutputStream;
 import io.scif.services.FormatService;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.List;
 
 import net.imagej.axis.Axes;
 import net.imglib2.Interval;
 
+import org.scijava.io.handle.DataHandle;
+import org.scijava.io.location.Location;
+import org.scijava.io.location.LocationService;
 import org.scijava.plugin.Plugin;
 
 /**
@@ -181,7 +183,7 @@ public class T3aCustomFormats {
 
 			// In this method we populate the given Metadata object
 			@Override
-			public void typedParse(final RandomAccessInputStream stream,
+			public void typedParse(final DataHandle<Location> handle,
 				final Metadata meta, final SCIFIOConfig config) throws IOException,
 				FormatException
 			{
@@ -337,9 +339,9 @@ public class T3aCustomFormats {
 				final Metadata meta = getMetadata();
 				System.out.println("Metadata = " + meta);
 
-				// This stream is the destination image to write to.
-				final RandomAccessOutputStream stream = getStream();
-				System.out.println("Stream = " + stream);
+				// This data handle is the destination image to write to.
+				final DataHandle<Location> dataHandle = getHandle();
+				System.out.println("DataHandle = " + dataHandle);
 
 				// The given Plane object is the source plane to write
 				final byte[] bytes = plane.getBytes();
@@ -450,7 +452,7 @@ public class T3aCustomFormats {
 	// *** END OF SAMPLE FORMAT ***
 
 	// This method is provided simply to confirm the format is discovered
-	public static void main(final String... args) throws FormatException {
+	public static void main(final String... args) throws FormatException, URISyntaxException {
 		// ------------------------------------------------------------------------
 		// COMPARISON WITH BIO-FORMATS 4.X
 		// In Bio-Formats 4.X, adding support for a new format required modifying
@@ -470,9 +472,12 @@ public class T3aCustomFormats {
 		// ... and a sample image path:
 		final String sampleImage = "notAnImage.scifiosmpl";
 
+		// Resolving the Location of this image.
+		Location location = scifio.get(LocationService.class).resolve(sampleImage);
+		
 		// As SampleFormat below was annotated as a @Plugin it should be available
 		// to our context:
-		final Format format = scifio.format().getFormat(sampleImage);
+		final Format format = scifio.format().getFormat(location);
 
 		// Verify that we found the format plugin
 		System.out.println("SampleFormat found via FormatService: " +

--- a/core/src/main/java/io/scif/tutorials/core/T3aCustomFormats.java
+++ b/core/src/main/java/io/scif/tutorials/core/T3aCustomFormats.java
@@ -473,7 +473,7 @@ public class T3aCustomFormats {
 		final String sampleImage = "notAnImage.scifiosmpl";
 
 		// Resolving the Location of this image.
-		Location location = scifio.get(LocationService.class).resolve(sampleImage);
+		Location location = scifio.location().resolve(sampleImage);
 		
 		// As SampleFormat below was annotated as a @Plugin it should be available
 		// to our context:

--- a/core/src/main/java/io/scif/tutorials/core/T3bTranslatingMetadata.java
+++ b/core/src/main/java/io/scif/tutorials/core/T3bTranslatingMetadata.java
@@ -24,11 +24,12 @@ import io.scif.ImageMetadata;
 import io.scif.Metadata;
 import io.scif.SCIFIO;
 import io.scif.Translator;
-import io.scif.formats.FakeFormat;
+import io.scif.formats.TestImgFormat;
 
 import java.io.IOException;
 import java.util.List;
 
+import org.scijava.io.location.Location;
 import org.scijava.plugin.Plugin;
 
 /**
@@ -55,13 +56,13 @@ public class T3bTranslatingMetadata {
 
 		// As usual, we start by creating a SCIFIO and our trusty sample image.
 		final SCIFIO scifio = new SCIFIO();
-		final String sampleImage =
-			"8bit-unsigned&pixelType=uint8&indexed=true&planarDims=3&lengths=50,50,3&axes=X,Y,Channel.fake";
+		
+		Location sampleImageLocation = FakeTutorialImages.sampleIndexedImage();
 
 		// First let's get a handle on a compatible Format, and parse the sample
 		// image's Metadata
-		final Format format = scifio.format().getFormat(sampleImage);
-		final Metadata input = format.createParser().parse(sampleImage);
+		final Format format = scifio.format().getFormat(sampleImageLocation);
+		final Metadata input = format.createParser().parse(sampleImageLocation);
 
 		// Now that we have some Metadata, let's find the MischeviousTranslator we
 		// defined below.
@@ -79,7 +80,7 @@ public class T3bTranslatingMetadata {
 
 		// To try the MischeviousTranslator out, let's get another copy
 		// of this image's Metadata.
-		final Metadata output = format.createParser().parse(sampleImage);
+		final Metadata output = format.createParser().parse(sampleImageLocation);
 
 		// Then we translate
 		t.translate(input, output);
@@ -116,7 +117,7 @@ public class T3bTranslatingMetadata {
 	 */
 	@Plugin(type = Translator.class)
 	public static class MischeviousTranslator extends
-		AbstractTranslator<FakeFormat.Metadata, FakeFormat.Metadata>
+		AbstractTranslator<TestImgFormat.Metadata, TestImgFormat.Metadata>
 	{
 
 		// -- Translator API methods --
@@ -129,7 +130,7 @@ public class T3bTranslatingMetadata {
 		 */
 		@Override
 		protected void translateImageMetadata(final List<ImageMetadata> source,
-			final FakeFormat.Metadata dest)
+			final TestImgFormat.Metadata dest)
 		{
 			// Here we would put our translation implementation, as in T3a.
 			System.out.println("Translating source: " + source + " to dest: " + dest);
@@ -137,12 +138,12 @@ public class T3bTranslatingMetadata {
 
 		@Override
 		public Class<? extends Metadata> source() {
-			return FakeFormat.Metadata.class;
+			return TestImgFormat.Metadata.class;
 		}
 
 		@Override
 		public Class<? extends Metadata> dest() {
-			return FakeFormat.Metadata.class;
+			return TestImgFormat.Metadata.class;
 		}
 	}
 }

--- a/ome/pom.xml
+++ b/ome/pom.xml
@@ -6,7 +6,6 @@
 		<groupId>io.scif</groupId>
 		<artifactId>pom-scifio-tutorials</artifactId>
 		<version>1.0.0-SNAPSHOT</version>
-		<relativePath />
 	</parent>
 
 	<groupId>io.scif</groupId>

--- a/ome/src/main/java/io/scif/tutorials/ome/T1OpeningOMEXML.java
+++ b/ome/src/main/java/io/scif/tutorials/ome/T1OpeningOMEXML.java
@@ -23,7 +23,11 @@ import io.scif.SCIFIO;
 import io.scif.ome.OMEMetadata;
 import io.scif.tutorials.core.T1dSavingImagePlanes;
 
+import java.net.URISyntaxException;
 import java.io.IOException;
+
+import org.scijava.io.location.Location;
+import org.scijava.io.location.LocationService;
 
 import loci.common.xml.XMLTools;
 
@@ -35,7 +39,7 @@ import loci.common.xml.XMLTools;
 public class T1OpeningOMEXML {
 
 	public static void main(final String... args) throws FormatException,
-		IOException
+		IOException, URISyntaxException
 	{
 		// Creation of OME-XML metadata in SCIFIO is accomplished via translation.
 		// The OME-XML component is essentially a collection of translators, from
@@ -44,12 +48,15 @@ public class T1OpeningOMEXML {
 		// translator to OME-XML. Luckily we already have a tutorial which creates a
 		// PNG image for us:
 		T1dSavingImagePlanes.main();
+		
+		// We'll need a context for discovering formats and translators
+		final SCIFIO scifio = new SCIFIO();
 
 		// Now we can reference the image we wrote via this path:
 		final String samplePNG = "SCIFIOTutorial.png";
-
-		// We'll need a context for discovering formats and translators
-		final SCIFIO scifio = new SCIFIO();
+		
+		// We can get the location of our samplePNG
+		Location location = scifio.get(LocationService.class).resolve(samplePNG);
 
 		// This is the Metadata object we will translate to OMEXML Metadata;
 		Metadata meta = null;
@@ -57,7 +64,7 @@ public class T1OpeningOMEXML {
 		// Since we are not going to be reading or writing any planes in this
 		// tutorial, we only need to populate the Metadata. To help us out, there
 		// is a very convenint method in the SCIFIO initializer:
-		meta = scifio.initializer().parseMetadata(samplePNG);
+		meta = scifio.initializer().parseMetadata(location);
 
 		// Now that we have our source Metadata, we will need OME-XML Metadata to
 		// translate to:

--- a/ome/src/main/java/io/scif/tutorials/ome/T1OpeningOMEXML.java
+++ b/ome/src/main/java/io/scif/tutorials/ome/T1OpeningOMEXML.java
@@ -56,7 +56,7 @@ public class T1OpeningOMEXML {
 		final String samplePNG = "SCIFIOTutorial.png";
 		
 		// We can get the location of our samplePNG
-		Location location = scifio.get(LocationService.class).resolve(samplePNG);
+		Location location = scifio.location().resolve(samplePNG);
 
 		// This is the Metadata object we will translate to OMEXML Metadata;
 		Metadata meta = null;

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>34.1.0</version>
+		<version>35.1.1</version>
 		<relativePath />
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>26.0.0</version>
+		<version>34.1.0</version>
 		<relativePath />
 	</parent>
 


### PR DESCRIPTION
closes #5 

This updates the tutorials to use the scijava location api.

Some things to note:

1. I made a class [FakeTutorialImages](https://github.com/scifio/scifio-tutorials/blob/scijava-location-api/core/src/main/java/io/scif/tutorials/core/FakeTutorialImages.java) to use the builder for getting fake image locations. There is a method [sampleIndexedImage](https://github.com/scifio/scifio-tutorials/blob/scijava-location-api/core/src/main/java/io/scif/tutorials/core/FakeTutorialImages.java#L36) where I'm not certain if that is the best name for the method, but it is used in [T2bTypedComponents.java](https://github.com/scifio/scifio-tutorials/blob/scijava-location-api/core/src/main/java/io/scif/tutorials/core/T2bTypedComponents.java#L77) to see if the Color table isn't null.
2. In [T1OpeningOMEXML](https://github.com/scifio/scifio-tutorials/blob/scijava-location-api/ome/src/main/java/io/scif/tutorials/ome/T1OpeningOMEXML.java) the class runs exactly the same, but for some reason there is an error when running. This is a log error at the top and doesn't kill the program
```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```

When it calls [T1dSavingImagePlanes.main();](https://github.com/scifio/scifio-tutorials/blob/scijava-location-api/ome/src/main/java/io/scif/tutorials/ome/T1OpeningOMEXML.java#L50) this error gets thrown at creating a new [SCIFIO instance](https://github.com/scifio/scifio-tutorials/blob/scijava-location-api/core/src/main/java/io/scif/tutorials/core/T1dSavingImagePlanes.java#L48), which I am not certain on currently.

